### PR TITLE
Refactor components to use theme spacing

### DIFF
--- a/src/components/Weather/WeatherFooter.tsx
+++ b/src/components/Weather/WeatherFooter.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { BodyPaddingProps } from "../../settings/default";
+import { weatherTheme } from "../../../theme/defaulttheme";
 
 const FooterField = ({children}: BodyPaddingProps) => {
     return(
-    <div style={{margin: "30px", padding: "40px", borderStyle: "dashed", borderWidth: "5px" }}
+    <div style={{
+        margin: weatherTheme.spacings.xl,
+        padding: weatherTheme.spacings.xxl,
+        borderStyle: weatherTheme.borders.styles.dashed,
+        borderWidth: weatherTheme.borders.widths.thick
+    }}
         >{children}
     </div>
     )

--- a/src/components/Weather/WeatherForm.tsx
+++ b/src/components/Weather/WeatherForm.tsx
@@ -4,12 +4,18 @@ import { NavBar } from "../Navbar/NavBar";
 import { WeatherHeader } from "./WeatherHeader";
 import { WeatherFooter } from "./WeatherFooter";
 import { BodyPaddingProps } from "../../settings/default";
+import { weatherTheme } from "../../../theme/defaulttheme";
 
 
 
 export const BodyPadding = ({children}: BodyPaddingProps) => {
     return(
-    <div style={{margin: "30px", padding: "40px", borderStyle: "dashed", borderWidth: "5px", }}
+    <div style={{
+        margin: weatherTheme.spacings.xl,
+        padding: weatherTheme.spacings.xxl,
+        borderStyle: weatherTheme.borders.styles.dashed,
+        borderWidth: weatherTheme.borders.widths.thick,
+    }}
         >{children}
     </div>
     )

--- a/src/components/Weather/WeatherHeader.tsx
+++ b/src/components/Weather/WeatherHeader.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import getWeather from "../../fake_api/weather_webfake";
 import { ButtonProps, ListOfWeathers, PaddingProps } from "../../settings/default";
+import { weatherTheme } from "../../../theme/defaulttheme";
 
 
 
@@ -29,7 +30,14 @@ const HeaderField = ({children}: PaddingProps) => {
     }
 
     return(
-        <div style={{margin: "30px", padding: "40px", borderStyle: "dashed", borderWidth: "5px", display: "flex", justifyContent: "center", }}
+        <div style={{
+            margin: weatherTheme.spacings.xl,
+            padding: weatherTheme.spacings.xxl,
+            borderStyle: weatherTheme.borders.styles.dashed,
+            borderWidth: weatherTheme.borders.widths.thick,
+            display: "flex",
+            justifyContent: "center",
+        }}
             >
             <div style={{display: "flex", justifyContent: "center", alignItems: 'center', flexDirection: "column"}}>
                 {children}            

--- a/theme/defaulttheme.tsx
+++ b/theme/defaulttheme.tsx
@@ -60,7 +60,19 @@ export const weatherTheme = {
         xl: 32,    // extra-large gap (wide margins, hero spacing)
         xxl: 40,   // extra-extra-large (full-width breaks, super spaced layouts)
     },
-      
+
+    borders: {
+        widths: {
+            thin: 1,
+            medium: 3,
+            thick: 5,
+        },
+        styles: {
+            solid: "solid",
+            dashed: "dashed",
+        },
+    },
+
     fontWeights: {
         normal: "normal",
         bold: "bold",


### PR DESCRIPTION
## Summary
- add border info to the weather theme
- use theme spacing and borders in `WeatherHeader`, `WeatherFooter`, and `WeatherForm`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684747ed95fc8326bb64f7a0c5c4e3b7